### PR TITLE
Fix custom algo

### DIFF
--- a/mcc/extract.py
+++ b/mcc/extract.py
@@ -17,12 +17,12 @@ import pickle
 from collections import Counter
 import pandas
 from tqdm import tqdm
-from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
+from sklearn.neighbors import KNeighborsClassifier
 from sklearn.ensemble import BaggingClassifier, AdaBoostClassifier
 from sklearn.naive_bayes import GaussianNB
 from sklearn.svm import SVC, LinearSVC
-from sklearn.tree import DecisionTreeRegressor, DecisionTreeClassifier
-from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
+from sklearn.tree import DecisionTreeClassifier
+from sklearn.ensemble import RandomForestClassifier
 from sklearn.neural_network import MLPClassifier
 from sklearn.model_selection import train_test_split
 import numpy as np

--- a/mcc/extract.py
+++ b/mcc/extract.py
@@ -105,14 +105,17 @@ class MyAlgo:
         # apply the mask
         copy_y[mask] = self.majority_class
         copy_y[~mask] = 0
-        # fit the binary classifier
-        self.binary.fit(training_x, copy_y)
-        # get the predictions
-        y_pred = self.binary.predict(training_x)
-        # filter the non majority class
-        mask = y_pred != self.majority_class
-        # fit on it
-        self.multi.fit(training_x[mask], training_y[mask])
+        # fit the binary classifier if the mask is enough
+        if np.any(mask):
+            self.binary.fit(training_x, copy_y)
+            # get the predictions
+            y_pred = self.binary.predict(training_x)
+            # filter the non majority class
+            mask = y_pred != self.majority_class
+            # fit on it
+            self.multi.fit(training_x[mask], training_y[mask])
+        else:
+            self.multi.fit(training_x, training_y)
 
     def predict(self, test_x):
         """Predict function. It predict the class, based on given features
@@ -120,7 +123,9 @@ class MyAlgo:
         test_x = np.array(test_x)
         y_pred = self.binary.predict(test_x)
         mask = y_pred != self.majority_class
-        y_pred[mask] = self.multi.predict(test_x[mask])
+        # to avoid the case of empty array
+        if np.any(mask):
+            y_pred[mask] = self.multi.predict(test_x[mask])
         return y_pred
 
     def score(self, test_x, test_y):

--- a/mcc/extract.py
+++ b/mcc/extract.py
@@ -299,15 +299,6 @@ if __name__ == "__main__":
         solver="lbfgs",
     )
 
-    # Regressor part
-    ALGORITHMS["decision-tree-regression"] = lambda _: DecisionTreeRegressor()
-
-    ALGORITHMS["knn-regression"] = lambda _: KNeighborsRegressor(
-        weights='distance', n_neighbors=30
-    )
-
-    ALGORITHMS["random-forest-regression"] = lambda _: RandomForestRegressor()
-
     # Custom part
     ALGORITHMS["custom-algo"] = lambda _: MyAlgo()
 


### PR DESCRIPTION
This will :
 * remove the false regression models
 * correct the custom-algo bug, issue #28 

For `$ ./extract.py --iterations=1 --duplicates=true`, it gives me that :
```
INFO: Tool marcie has score 3217.
INFO: Tool gspn has score 3031.
INFO: Tool smart has score 488.
INFO: Tool tedd has score 703.
INFO: Tool sift has score 320.
INFO: Tool spot has score 462.
INFO: Tool ltsmin has score 6575.
INFO: Tool lola has score 7994.
INFO: Tool tapaal has score 3181.
INFO: Tool itstools has score 5065.
INFO: Tool pecan has score 4006.
INFO: Tool pnmc has score 762.
INFO: Tool pnxdd has score 354.
INFO: Tool tapaalEXP has score 2389.
INFO: Tool tapaalPAR has score 2179.
INFO: Tool tapaalSEQ has score 2965.
INFO: Tool yddpt has score 125.
INFO: Algorithm naive-bayes has score 3823.
INFO: Algorithm svm has score 8975.
INFO: Algorithm ada-boost has score 7643.
INFO: Algorithm linear-svm has score 7346.
INFO: Algorithm decision-tree has score 9679.
INFO: Algorithm random-forest has score 9724.
INFO: Algorithm neural-network has score 7929.
INFO: Algorithm custom-algo has score 9601.
```
The custom-aglo reach 9601, i have some idea to improve it.